### PR TITLE
Automatically fetch latest Tribler release from GH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+**.DS_Store
+.idea/**

--- a/download.html
+++ b/download.html
@@ -16,10 +16,12 @@
 
 
 
-<script src="/js/wow.min.js"></script>
+<script src="js/wow.min.js"></script>
 <script>
  new WOW().init();
 </script>
+
+<script type="text/javascript" src="js/jquery-1.10.2.min.js"></script>
 
 <!--<script type="text/javascript">-->
       <!--var uservoiceOptions = {-->
@@ -88,16 +90,16 @@
 	</header>
 
 	<div id="wrap"><br>
-		<section id="content">
+		<section id="content" class="downloads-content">
 			<div class="download">
 				<p class="title">Windows</p>
 
 				<p><img src="img/win.png" width=100px height=100px></p>
 
 				<p>
-					<a href="https://github.com/Tribler/tribler/releases/download/v7.1.3/Tribler_7.1.3_x64.exe">Download .exe (64-bit)</a><br>
-					<a href="https://github.com/Tribler/tribler/releases/download/v7.1.3/Tribler_7.1.3_x86.exe">Download .exe (32-bit)</a><br>
-					Windows Vista, and Windows 7 / 8 / 10
+					<a id="download-url-win64" href="">Download .exe (64-bit)</a><br>
+					<a id="download-url-win32" href="">Download .exe (32-bit)</a><br>
+					Windows 7 / 8 / 10
 				</p>
 			</div>
 
@@ -107,7 +109,7 @@
 				<p><img src="img/osx.png" width=100px height=100px></p>
 
 				<p>
-					<a href="https://github.com/Tribler/tribler/releases/download/v7.1.3/Tribler-7.1.3.dmg">Download .dmg</a></br>
+					<a id="download-url-mac" href="">Download .dmg</a></br>
 					(Yosemite or newer)
 				</p>
 			</div>
@@ -117,18 +119,18 @@
 
 				<p><img src="img/linux.png" width=100px height=100px></p>
 
-				<p><a href="https://github.com/Tribler/tribler/releases/download/v7.1.3/tribler_7.1.3_all.deb">Download .deb</a> </p>
+				<p><a id="download-url-linux" href="">Download .deb</a> </p>
 
-				<p><a href="https://github.com/Tribler/tribler/tree/v7.1.3">Browse source code </a> <br/>
-					<a href="https://github.com/Tribler/tribler/archive/v7.1.3.tar.gz">Download source tar</a><br>
+				<p><a class="tribler-source-tree-url" href="">Browse source code </a> <br/>
+					<a id="tribler-source-url" href="">Download source tar</a><br>
 					<a class='dim' href="./linux.html">More information ...</a>
 				</p>
 
 			</div>
 
 			<div class="changelog">
-			    <p>To see the short changelog <a href="https://github.com/Tribler/tribler/tree/v7.1.3">click here</a>.</p>
-			    <p>To see a complete list of the changes, please <a href="https://github.com/Tribler/tribler/compare/v7.1.2...v7.1.3">click here</a>.</p>
+			    <p>To see the short changelog <a class="tribler-source-tree-url" href="">click here</a>.</p>
+			    <p>To see a complete list of the changes, please <a id="github-compare-url" href="">click here</a>.</p>
 			</div>
 
 		</section>
@@ -142,5 +144,6 @@
 
 	  gtag('config', 'UA-111501715-1');
 	</script>
+	<script src="js/tribler.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -112,7 +112,7 @@
 
 			<div class="download_section">
 				<p id="download_os">For Windows/macOS/Linux</p>
-				<a id="main_download_url" class="download_url" href="download.html">Download Tribler 7.1.3</a><br/>
+				<a id="main_download_url" class="download_url" href="download.html">Download Tribler</a><br/>
 				<a id="instructions" style="" href=""></a>
 				<span id="download_page">More options on <a href="download.html">downloads page</a></span>
 				<div id="release_dlcount">Total Downloads: <span id="total_downloads_all_versions">...</span></div>
@@ -185,53 +185,11 @@
 
 		<div class="download_section">
 			<p id="footer_download_os">For Windows/macOS/Linux</p>
-			<a id="footer_download_url" class="download_url" href="download.html">Download Tribler 7.1.3</a><br/>
+			<a id="footer_download_url" class="download_url" href="download.html">Download Tribler</a><br/>
 		</div>
 		<br/>
 
 	</footer>
-
-	<script type="text/javascript">
-	$(document).ready(function(){
-		var parser = new UAParser();
-		var result = parser.getResult();
-		var osName = result.os.name.toLowerCase();
-		if (osName == "windows") {
-			$("#download_os").html("For Windows 10/8/7/Vista");
-			$("#main_download_url").attr("href","https://github.com/Tribler/tribler/releases/download/v7.1.3/Tribler_7.1.3_x64.exe");
-			$("#footer_download_url").attr("href","https://github.com/Tribler/tribler/releases/download/v7.1.3/Tribler_7.1.3_x64.exe");
-		}
-		else if (osName == "mac os x") {
-			$("#download_os").html("For macOS (Yosemite or later)");
-			$("#main_download_url").attr("href","https://github.com/Tribler/tribler/releases/download/v7.1.3/Tribler-7.1.3.dmg");
-			$("#footer_download_url").attr("href","https://github.com/Tribler/tribler/releases/download/v7.1.3/Tribler-7.1.3.dmg");
-		}
-		else if (jQuery.inArray(osName, new Array('kubuntu', 'xubuntu', 'lubuntu', 'ubuntu', 'gentoo', 'fedora', 'mandriva', 'redhat', 'suse', 'debian', 'slackware', 'arch', 'linux')) !== -1) {
-			$("#download_os").html("For Linux");
-			$("#main_download_url").attr("href","https://github.com/Tribler/tribler/releases/download/v7.1.3/Tribler_7.1.3_all.deb");
-			$("#footer_download_url").attr("href","https://github.com/Tribler/tribler/releases/download/v7.1.3/Tribler_7.1.3_all.deb");
-			$("#instructions").html("Installation instructions for Linux");
-			$("#instructions").css("display", "block");
-			$("#instructions").attr("href", "./linux.html");
-		}
-		else {
-			$("#download_os").html("Unknown OS");
-			$("#main_download_url").attr("href","download.html");
-			$("#footer_download_url").attr("href","download.html");
-		}
-	});
-	</script>
-	<script>
-		$.get( "https://api.github.com/repos/Tribler/tribler/releases", function( data ) {
-			var total = 0;
-			$.each(data, function(index, release){
-				$.each(release["assets"], function(index2, asset){
-					total += asset["download_count"];
-				});
-			});
-			document.getElementById('total_downloads_all_versions').innerHTML = total;
-		});
-	</script>
 	<!-- Global site tag (gtag.js) - Google Analytics -->
 	<script async src="https://www.googletagmanager.com/gtag/js?id=UA-111501715-1"></script>
 	<script>
@@ -241,5 +199,6 @@
 
 	  gtag('config', 'UA-111501715-1');
 	</script>
+	<script src="js/tribler.js"></script>
 </body>
 </html>

--- a/js/tribler.js
+++ b/js/tribler.js
@@ -1,0 +1,107 @@
+$(document).ready(function() {
+    pagename = location.href.substring(location.href.lastIndexOf('/')+1);
+    if(pagename == "linux.html") {
+        $("#debian-install-code").hide()
+    }
+    else if(pagename == "download.html") {
+        $(".downloads-content").hide()
+    }
+
+    $.get("https://api.github.com/repos/Tribler/tribler/releases", function (data) {
+        var total = 0;
+        var stablerelease = undefined;
+        var prevrelease = undefined;
+        $.each(data, function (index, release) {
+            $.each(release["assets"], function (index2, asset) {
+                total += asset["download_count"];
+            });
+
+            if (!release["prerelease"] && !stablerelease) {
+                // we found a stable release; update fields
+                stablerelease = release;
+                $("#main_download_url").text("Download Tribler " + release["name"].substring(1))
+                $("#footer_download_url").text("Download Tribler " + release["name"].substring(1))
+            }
+            else if(!release["prerelease"] && !prevrelease && stablerelease) {
+                prevrelease = release;
+            }
+        });
+
+        // find the right assets in the stable release
+        windows64_url = undefined;
+        windows32_url = undefined;
+        mac_url = undefined;
+        linux_url = undefined;
+        linux_file_name = undefined;
+        source_url = undefined;
+        $.each(stablerelease["assets"], function(index, asset) {
+            if(asset["name"].endsWith(".dmg")) {
+                mac_url = asset["browser_download_url"];
+            }
+            else if(asset["name"].endsWith(".deb")) {
+                linux_url = asset["browser_download_url"];
+                linux_file_name = asset["name"];
+            }
+            else if(asset["name"].endsWith("x64.exe")) {
+                windows64_url = asset["browser_download_url"];
+            }
+            else if(asset["name"].endsWith("tar.xz")) {
+                source_url = asset["browser_download_url"];
+            }
+        });
+
+        if(pagename == "index.html") {
+            $('#total_downloads_all_versions').innerHTML = total;
+
+            // set download URLs
+            var parser = new UAParser();
+            var result = parser.getResult();
+            var osName = result.os.name.toLowerCase();
+            if (osName == "windows") {
+                $("#download_os").html("For Windows 7/8/10");
+                $("#main_download_url").attr("href", windows64_url);
+                $("#footer_download_url").attr("href", windows64_url);
+            }
+            else if (osName == "mac os x") {
+                $("#download_os").html("For macOS (Yosemite or later)");
+                $("#main_download_url").attr("href", mac_url);
+                $("#footer_download_url").attr("href", mac_url);
+            }
+            else if (jQuery.inArray(osName, new Array('kubuntu', 'xubuntu', 'lubuntu', 'ubuntu', 'gentoo', 'fedora', 'mandriva', 'redhat', 'suse', 'debian', 'slackware', 'arch', 'linux')) !== -1) {
+                $("#download_os").html("For Linux");
+                $("#main_download_url").attr("href", linux_url);
+                $("#footer_download_url").attr("href", linux_url);
+                $("#instructions").html("Installation instructions for Linux");
+                $("#instructions").css("display", "block");
+                $("#instructions").attr("href", "./linux.html");
+            }
+            else {
+                $("#download_os").html("Unknown OS");
+                $("#main_download_url").attr("href","download.html");
+                $("#footer_download_url").attr("href","download.html");
+            }
+        }
+        else if(pagename == "linux.html") {
+            $("#linux-content-header").text("Latest release - Tribler " + stablerelease["name"].substring(1));
+            $("#debian-download-url").attr("href", linux_url);
+            $("#debian-download-url").text("Download " + stablerelease["name"].substring(1));
+            $("#tribler-source-url").attr("href", source_url);
+            $("#tribler-source-tree-url").attr("href", 'https://github.com/Tribler/tribler/tree/' + stablerelease['tag_name']);
+
+            $("#debian-install-code-url").text(linux_url);
+            $("#debian-install-code-file").text("./" + linux_file_name);
+            $("#debian-install-code").show();
+        }
+        else if(pagename == "download.html") {
+            $("#download-url-win64").attr("href", windows64_url);
+            $("#download-url-win32").attr("href", windows32_url);
+            $("#download-url-mac").attr("href", mac_url);
+            $("#download-url-linux").attr("href", linux_url);
+            $("#tribler-source-url").attr("href", source_url);
+            $(".tribler-source-tree-url").attr("href", 'https://github.com/Tribler/tribler/tree/' + stablerelease['tag_name']);
+            $(".downloads-content").show()
+            $("#github-compare-url").attr("href", 'https://github.com/Tribler/tribler/compare/' + prevrelease['tag_name'] + '...' + stablerelease['tag_name'])
+        }
+
+    });
+});

--- a/linux.html
+++ b/linux.html
@@ -67,29 +67,29 @@
 
     <div id="wrap"><br>
 
-		<section id="content">
+		<section class="linux-content" id="content">
 			<div>
 				<h1>Tribler for Linux</h1>
 				<p class="title"><img src="img/linux.png" alt="" /></p>
 			</div>
 
-			<h2 class="light">Latest release - Tribler 7.1.3</h2>
+			<h2 id="linux-content-header" class="light">Latest release -</h2>
 
 			<p>
 				<ul>
-					<li>➜ Debian Package <a class='download_button_small' href="https://github.com/Tribler/tribler/releases/download/v7.1.3/tribler_7.1.3_all.deb">Download 7.1.3</a> </li>
-					<li><strong>➜ Source tar file</strong> <a href="https://github.com/Tribler/tribler/releases/download/v7.1.3/Tribler-v7.1.3.tar.gz">Download</a> </li>
-					<li><strong>➜ Source code</strong> <a target="_blank" href="https://github.com/Tribler/tribler/tree/v7.1.3">Github</a> </li>
+					<li>➜ Debian Package <a id="debian-download-url" class='download_button_small' href="download.html">Download</a> </li>
+					<li><strong>➜ Source tar file</strong> <a id="tribler-source-url" href="download.html">Download</a> </li>
+					<li><strong>➜ Source code</strong> <a id="tribler-source-tree-url" target="_blank" href="download.html">Github</a> </li>
 				</ul>
 
 			</p>
             <br/>
 			<div>
 				<h2 class="light">Installation instructions</h2>
-				<blockquote style="border-left:2px solid #fff; padding-left:16px">
+				<blockquote id="debian-install-code" style="border-left:2px solid #fff; padding-left:16px">
 					<pre>
-wget https://github.com/Tribler/tribler/releases/download/v7.1.3/tribler_7.1.3_all.deb
-sudo apt-get install ./tribler_7.1.3_all.deb</pre>
+wget <span id="debian-install-code-url"></span>
+sudo apt-get install <span id="debian-install-code-file"></span></pre>
 				</blockquote>
 			</div>
 			<br/>
@@ -119,5 +119,6 @@ sudo apt-get install ./tribler_7.1.3_all.deb</pre>
 
 	  gtag('config', 'UA-111501715-1');
 	</script>
+	<script src="js/tribler.js"></script>
 </body>
 </html>


### PR DESCRIPTION
With these changes, the latest version of Tribler is automatically pulled from Github and displayed to the user. This means we don't need to update the website whenever we are doing a release 👍 