### PR TITLE
Fixed total downloads count

### DIFF
--- a/js/tribler.js
+++ b/js/tribler.js
@@ -7,26 +7,7 @@ $(document).ready(function() {
         $(".downloads-content").hide()
     }
 
-    $.get("https://api.github.com/repos/Tribler/tribler/releases", function (data) {
-        var total = 0;
-        var stablerelease = undefined;
-        var prevrelease = undefined;
-        $.each(data, function (index, release) {
-            $.each(release["assets"], function (index2, asset) {
-                total += asset["download_count"];
-            });
-
-            if (!release["prerelease"] && !stablerelease) {
-                // we found a stable release; update fields
-                stablerelease = release;
-                $("#main_download_url").text("Download Tribler " + release["name"].substring(1))
-                $("#footer_download_url").text("Download Tribler " + release["name"].substring(1))
-            }
-            else if(!release["prerelease"] && !prevrelease && stablerelease) {
-                prevrelease = release;
-            }
-        });
-
+    function update_page(stablerelease){
         // find the right assets in the stable release
         windows64_url = undefined;
         windows32_url = undefined;
@@ -54,8 +35,6 @@ $(document).ready(function() {
         });
 
         if(typeof(isfront) !== 'undefined') {
-            $("#total_downloads_all_versions").html(total);
-
             // set download URLs
             var parser = new UAParser();
             var result = parser.getResult();
@@ -105,6 +84,42 @@ $(document).ready(function() {
             $(".downloads-content").show()
             $("#github-compare-url").attr("href", 'https://github.com/Tribler/tribler/compare/' + prevrelease['tag_name'] + '...' + stablerelease['tag_name'])
         }
+    }
 
-    });
+    // Fetch the first release page of the API to show the latest stable release.
+    $.get("https://api.github.com/repos/Tribler/tribler/releases", function (data) {
+            var stablerelease = undefined;
+            var prevrelease = undefined;
+            $.each(data, function (index, release) {
+                if (!release["prerelease"] && !stablerelease) {
+                    // we found a stable release; update fields
+                    stablerelease = release;
+                    $("#main_download_url").text("Download Tribler " + release["name"].substring(1));
+                    $("#footer_download_url").text("Download Tribler " + release["name"].substring(1));
+                    update_page(stablerelease);
+                }
+                else if(!release["prerelease"] && !prevrelease && stablerelease) {
+                    prevrelease = release;
+                }
+            });
+        });
+
+    // Fetch all the releases from the API and get aggregate sum of downloads.
+    var releases_page = 1;
+    var max_page = 10;
+    var next_page_exists = true;
+    var total_downloads = 0;
+    do{
+        $.get("https://api.github.com/repos/Tribler/tribler/releases?page="+releases_page, function (releases) {
+            next_page_exists = releases.length != 0
+            $.each(releases, function (index, release) {
+                $.each(release["assets"], function (index2, asset) {
+                    total_downloads += asset["download_count"];
+                    $("#total_downloads_all_versions").html(total_downloads.toLocaleString());
+                });
+            });
+        });
+        releases_page += 1
+    }while(next_page_exists && releases_page < max_page);
+
 });


### PR DESCRIPTION
Fixes total downloads count. This should have the issue with rendering the old stable version in the downloads section. The issue was likely caused by the async nature of javascript callback and local caching where results for the older pages (fetched last) are cached and returned faster than the response for the first-page release response.