### PR TITLE
Implement some common meta headers

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,11 @@
 	<meta charset="utf-8" />
 	<title>Tribler - Privacy using our Tor-inspired onion routing</title>
 
+    <meta http-equiv="Strict-Transport-Security" content="max-age=63072000; includeSubDomains; preload">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; upgrade-insecure-requests">
+    <meta http-equiv="X-Content-Type-Options" content="nosniff">
+    <meta http-equiv="X-Frame-Options" content="SAMEORIGIN">
+
 	<meta name="description" content="Tribler is a powerful and censorship resistant peer-to-peer decentralized torrent client, providing fast and privacy enhanced file-sharing experiences using Tor-inspired onion routing. Download and share torrents with ease.">
 	<meta name="keywords" content="Tribler, torrent client, peer-to-peer, decentralized, file sharing">
 


### PR DESCRIPTION
This should mostly fix https://github.com/Tribler/tribler/issues/5577

- Subresource Integrity (SRI) does not work with the Google tag script.
- `Initial redirection from HTTP to HTTPS is to a different host, preventing HSTS` should be done in the DNS entry.